### PR TITLE
Use protected vars in Monitor.php

### DIFF
--- a/code/Model/Monitor.php
+++ b/code/Model/Monitor.php
@@ -2,18 +2,18 @@
 
 class BlueAcorn_UniversalAnalytics_Model_Monitor {
 
-    private $productImpressionList = Array();
-    private $promoImpressionList   = Array();
+    protected $productImpressionList = Array();
+    protected $promoImpressionList   = Array();
 
-    private $quoteList = Array();
+    protected $quoteList = Array();
 
-    private $productAttributeValueList = Array();
+    protected $productAttributeValueList = Array();
 
-    private $exclusionList = Array();
+    protected $exclusionList = Array();
 
-    private $action = null;
+    protected $action = null;
 
-    private $helper;
+    protected $helper;
 
     /**
      * Constructor, sets up a shortcut variable for the main helper


### PR DESCRIPTION
Using protected vars will make this class easier to rewrite, and extend.

On a recent project I had to customise a few methods, which in order to do so I had to copy this file into `app/code/local` to change to protected vars, so I could eventually do a rewrite.
